### PR TITLE
Use alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:6.10-alpine
 
 RUN npm install -g mountebank --production
 


### PR DESCRIPTION
Using node:alpine leads to smaller images (from 674MB down to 66.4MB). I chose a more explicit node version 6.10. in this case.